### PR TITLE
For socrata/opendatanetwork.com#529: Adding `per100k` formatter

### DIFF
--- a/app/data/values/format.js
+++ b/app/data/values/format.js
@@ -17,6 +17,7 @@ const precisionPrefix = 'precision';
 function format(type) {
     if (type === 'percent') return n => numeral(n / 100).format(numeralFormatters.percent);
     if (type === 'per1000') return n => numeral(n / 100000).format(numeralFormatters.percent);
+    if (type === 'ratio100k') return n => numeral(n * 100000).format(numeralFormatters.number);
     const formatter = numeralFormatters[type] || precisionFormatter(type) || '';
     return number => numeral(number).format(formatter);
 }

--- a/data/sources.json
+++ b/data/sources.json
@@ -379,7 +379,7 @@
                     },
                     "rate": {
                         "name": "Crime incident rate per 100,000 people",
-                        "type": "precision3"
+                        "type": "ratio100k"
                     }
                 },
                 "searchTerms": ["crime", "policing", "public safety", "arrest", "warrant", "police"],


### PR DESCRIPTION
@aaasen you were close with https://github.com/socrata/odn-backend/commit/8bfe8ae50fc88a47ac1e950ee1391f0284148e15, but the ratio needed to be adjusted based on 100k populations

Can you CR this when you get a chance?