### PR TITLE
EN-19762: ODN Formatting Issues (backend changes)

### DIFF
--- a/data/sources.json
+++ b/data/sources.json
@@ -671,7 +671,7 @@
                     },
                     "long_term_debt_revenue": {
                         "name": "Long Term Debt Revenue",
-                        "type": "percent"
+                        "type": "ratio"
                     }
                     ,
                     "debt_health": {
@@ -724,7 +724,7 @@
                     },
                      "general_fund_unrestricted_balance": {
                         "name": "General Fund Unrestricted Balance",
-                        "type": "dollar",
+                        "type": "ratio",
                         "stoplight": true
                     },
                     "general_fund_health": {


### PR DESCRIPTION
The displayed tooltips of the ODN charts uses the formatted data string coming from the backend.  This bug had to do with the tooltips of the Michigan Long Term Debt Revenue and General Fund Unrestricted Balance being off my two decimal places.

Fix is to change the formatter from percent to ratio.