### PR TITLE
EN-37311: GITHUB Vulnerability : HIGH : socrata / odn-backend : handl…

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,17 +3,12 @@
 process.isDevelopment = process.env.NODE_ENV === 'development';
 process.isProduction = !process.isDevelopment;
 
-const istanbul = require('istanbul-middleware');
-if (process.isDevelopment) istanbul.hookLoader(__dirname);
-
 const app = require('express')();
 const http = require('http').Server(app);
 const io = require('socket.io')(http);
 
 app.use(require('compression')());
 app.use(require('cors')());
-
-if (process.isDevelopment) app.use('/coverage', istanbul.createHandler());
 
 app.get('/', require('./app/home'));
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,8 @@
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/abbrev/-/abbrev-1.0.9.tgz",
-      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU="
+      "integrity": "sha1-kbR5JYinc4wl813W9jdSovh3YTU=",
+      "dev": true
     },
     "accepts": {
       "version": "1.3.4",
@@ -33,22 +34,6 @@
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.3.0"
       }
-    },
-    "align-text": {
-      "version": "0.1.4",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/align-text/-/align-text-0.1.4.tgz",
-      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "optional": true,
-      "requires": {
-        "kind-of": "^3.0.2",
-        "longest": "^1.0.1",
-        "repeat-string": "^1.5.2"
-      }
-    },
-    "amdefine": {
-      "version": "1.0.1",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -127,63 +112,6 @@
       "requires": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
-      }
-    },
-    "archiver": {
-      "version": "0.14.4",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.14.4.tgz",
-      "integrity": "sha1-W53bn17hzu8hy487Ag5iQOy0MVw=",
-      "requires": {
-        "async": "~0.9.0",
-        "buffer-crc32": "~0.2.1",
-        "glob": "~4.3.0",
-        "lazystream": "~0.1.0",
-        "lodash": "~3.2.0",
-        "readable-stream": "~1.0.26",
-        "tar-stream": "~1.1.0",
-        "zip-stream": "~0.5.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "0.9.2",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/async/-/async-0.9.2.tgz",
-          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
-        },
-        "glob": {
-          "version": "4.3.5",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz",
-          "integrity": "sha1-gPuwjKVA8jiszl0R0em8QedRc9M=",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^2.0.1",
-            "once": "^1.3.0"
-          }
-        },
-        "lodash": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs="
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-2.0.10.tgz",
-          "integrity": "sha1-jQh8OcazjAAbl/ynzm0OHoCvusc=",
-          "requires": {
-            "brace-expansion": "^1.0.0"
-          }
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
       }
     },
     "archiver-utils": {
@@ -382,7 +310,8 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base64-arraybuffer": {
       "version": "0.1.5",
@@ -433,27 +362,6 @@
       "integrity": "sha1-I8DfFPaogHf1+YbA0WfsA8PVU3w=",
       "dev": true
     },
-    "bl": {
-      "version": "0.9.5",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/bl/-/bl-0.9.5.tgz",
-      "integrity": "sha1-wGt5evCF6gC8Unr8jvzxHeIjIFQ=",
-      "requires": {
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
-    },
     "blob": {
       "version": "0.0.5",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/blob/-/blob-0.0.5.tgz",
@@ -463,52 +371,6 @@
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
       "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
-    },
-    "body-parser": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.12.4.tgz",
-      "integrity": "sha1-CQcAxLoohiqFIO83g5X97l9hwik=",
-      "requires": {
-        "bytes": "1.0.0",
-        "content-type": "~1.0.1",
-        "debug": "~2.2.0",
-        "depd": "~1.0.1",
-        "iconv-lite": "0.4.8",
-        "on-finished": "~2.2.1",
-        "qs": "2.4.2",
-        "raw-body": "~2.0.1",
-        "type-is": "~1.6.2"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
-          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g="
-        },
-        "depd": {
-          "version": "1.0.1",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/depd/-/depd-1.0.1.tgz",
-          "integrity": "sha1-gK7GTJ1tl+ZcwqnKqTwKpqv3Oqo="
-        },
-        "ee-first": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz",
-          "integrity": "sha1-ag18YiHkkP7v2S7D9EHJzozQl/Q="
-        },
-        "on-finished": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.1.tgz",
-          "integrity": "sha1-XIXBzDYpn3gCllP2Z/J7a5nrwCk=",
-          "requires": {
-            "ee-first": "1.1.0"
-          }
-        },
-        "qs": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz",
-          "integrity": "sha1-9854jld33wtQENp/fE5zujJHD1o="
-        }
-      }
     },
     "boom": {
       "version": "4.3.1",
@@ -611,6 +473,7 @@
       "version": "1.1.8",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -660,7 +523,8 @@
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+      "dev": true
     },
     "buffer-fill": {
       "version": "1.0.0",
@@ -687,7 +551,8 @@
     "camelcase": {
       "version": "1.2.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/camelcase/-/camelcase-1.2.1.tgz",
-      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk="
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+      "dev": true
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -699,16 +564,6 @@
       "version": "0.12.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
-    },
-    "center-align": {
-      "version": "0.1.3",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/center-align/-/center-align-0.1.3.tgz",
-      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.3",
-        "lazy-cache": "^1.0.3"
-      }
     },
     "chai": {
       "version": "3.5.0",
@@ -867,25 +722,6 @@
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
-    },
-    "cliui": {
-      "version": "2.1.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/cliui/-/cliui-2.1.0.tgz",
-      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
-      "optional": true,
-      "requires": {
-        "center-align": "^0.1.1",
-        "right-align": "^0.1.1",
-        "wordwrap": "0.0.2"
-      },
-      "dependencies": {
-        "wordwrap": {
-          "version": "0.0.2",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.2.tgz",
-          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
-          "optional": true
-        }
-      }
     },
     "co": {
       "version": "4.6.0",
@@ -1132,30 +968,6 @@
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/component-inherit/-/component-inherit-0.0.3.tgz",
       "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
     },
-    "compress-commons": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-0.2.9.tgz",
-      "integrity": "sha1-Qi2SdDDAGr0GzUVbbfwEy0z4ADw=",
-      "requires": {
-        "buffer-crc32": "~0.2.1",
-        "crc32-stream": "~0.3.1",
-        "node-int64": "~0.3.0",
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
-    },
     "compressible": {
       "version": "2.0.17",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/compressible/-/compressible-2.0.17.tgz",
@@ -1235,7 +1047,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
@@ -1354,28 +1167,6 @@
       "dev": true,
       "requires": {
         "buffer": "^5.1.0"
-      }
-    },
-    "crc32-stream": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-0.3.4.tgz",
-      "integrity": "sha1-c7wltF+sHbZjIjGnv86JJ+nwZVI=",
-      "requires": {
-        "buffer-crc32": "~0.2.1",
-        "readable-stream": "~1.0.24"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
       }
     },
     "create-error-class": {
@@ -1503,6 +1294,7 @@
       "version": "2.2.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/debug/-/debug-2.2.0.tgz",
       "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
       "requires": {
         "ms": "0.7.1"
       }
@@ -1510,7 +1302,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "declare.js": {
       "version": "0.0.8",
@@ -1582,11 +1375,6 @@
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha1-xPp8lUBKF6nD6Mp+FTcxK3NjMKw=",
       "dev": true
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "deepmerge": {
       "version": "1.5.2",
@@ -1721,6 +1509,7 @@
       "version": "1.4.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/end-of-stream/-/end-of-stream-1.4.0.tgz",
       "integrity": "sha1-epDYM+/abPpurA9JSduw+tOmMgY=",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -1824,32 +1613,10 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
       "dev": true
     },
-    "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
-      "requires": {
-        "esprima": "^2.7.1",
-        "estraverse": "^1.9.1",
-        "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.2.0"
-      }
-    },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
-    },
-    "estraverse": {
-      "version": "1.9.3",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/estraverse/-/estraverse-1.9.3.tgz",
-      "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
-    },
-    "esutils": {
-      "version": "2.0.2",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "version": "4.0.1",
+      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha1-E7BM2z5sXRnfkatph6hpVhmwqnE="
     },
     "etag": {
       "version": "1.8.1",
@@ -2076,11 +1843,6 @@
       "version": "2.0.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
       "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fill-range": {
       "version": "7.0.1",
@@ -2336,32 +2098,6 @@
       "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
       "dev": true
     },
-    "handlebars": {
-      "version": "4.0.11",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
-      "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
-      "requires": {
-        "async": "^1.4.0",
-        "optimist": "^0.6.1",
-        "source-map": "^0.4.4",
-        "uglify-js": "^2.6"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "source-map": {
-          "version": "0.4.4",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.4.4.tgz",
-          "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
-          "requires": {
-            "amdefine": ">=0.0.4"
-          }
-        }
-      }
-    },
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/har-schema/-/har-schema-2.0.0.tgz",
@@ -2404,11 +2140,6 @@
       "version": "1.1.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/has-cors/-/has-cors-1.1.0.tgz",
       "integrity": "sha1-XkdHk/fqmEPRu5nCPu9J/xJv/zk="
-    },
-    "has-flag": {
-      "version": "1.0.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/has-flag/-/has-flag-1.0.0.tgz",
-      "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
     },
     "has-symbols": {
       "version": "1.0.1",
@@ -2495,11 +2226,6 @@
         "sshpk": "^1.7.0"
       }
     },
-    "iconv-lite": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.8.tgz",
-      "integrity": "sha1-xgGadZXyzvynAuq2lKAQvNkpjSA="
-    },
     "ieee754": {
       "version": "1.1.13",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/ieee754/-/ieee754-1.1.13.tgz",
@@ -2533,6 +2259,7 @@
       "version": "1.0.6",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2568,12 +2295,6 @@
       "requires": {
         "binary-extensions": "^2.0.0"
       }
-    },
-    "is-buffer": {
-      "version": "1.1.6",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-      "optional": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -2710,84 +2431,19 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "istanbul": {
-      "version": "0.4.5",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/istanbul/-/istanbul-0.4.5.tgz",
-      "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
-      "requires": {
-        "abbrev": "1.0.x",
-        "async": "1.x",
-        "escodegen": "1.8.x",
-        "esprima": "2.7.x",
-        "glob": "^5.0.15",
-        "handlebars": "^4.0.1",
-        "js-yaml": "3.x",
-        "mkdirp": "0.5.x",
-        "nopt": "3.x",
-        "once": "1.x",
-        "resolve": "1.1.x",
-        "supports-color": "^3.1.0",
-        "which": "^1.1.1",
-        "wordwrap": "^1.0.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        },
-        "glob": {
-          "version": "5.0.15",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/glob/-/glob-5.0.15.tgz",
-          "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "requires": {
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "2 || 3",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/minimatch/-/minimatch-3.0.4.tgz",
-          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
-          "requires": {
-            "brace-expansion": "^1.1.7"
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/supports-color/-/supports-color-3.2.3.tgz",
-          "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
-          "requires": {
-            "has-flag": "^1.0.0"
-          }
-        }
-      }
-    },
-    "istanbul-middleware": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/istanbul-middleware/-/istanbul-middleware-0.2.2.tgz",
-      "integrity": "sha1-g8TBPBKOGg1qFHeSORrzwVqKuOA=",
-      "requires": {
-        "archiver": "0.14.x",
-        "body-parser": "~1.12.3",
-        "express": "4.x",
-        "istanbul": "0.4.x"
-      }
     },
     "jade": {
       "version": "0.26.3",
@@ -2814,19 +2470,12 @@
       }
     },
     "js-yaml": {
-      "version": "3.10.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-3.10.0.tgz",
-      "integrity": "sha1-LnhEFka9RoLpY/IrbpKCPDCcYtw=",
+      "version": "3.13.1",
+      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha1-r/FRswv9+o5J4F2iLnQV6d+jeEc=",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
-      },
-      "dependencies": {
-        "esprima": {
-          "version": "4.0.0",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/esprima/-/esprima-4.0.0.tgz",
-          "integrity": "sha1-RJnt3NERDgshi6zy+n9/WfVcqAQ="
-        }
       }
     },
     "jsbn": {
@@ -2902,15 +2551,6 @@
       "resolved": "https://registry.npmjs.org/keypress/-/keypress-0.2.1.tgz",
       "integrity": "sha1-HoBFQlABjbrUw/6USX1uZ7YmnHc="
     },
-    "kind-of": {
-      "version": "3.2.2",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/kind-of/-/kind-of-3.2.2.tgz",
-      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "optional": true,
-      "requires": {
-        "is-buffer": "^1.1.5"
-      }
-    },
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/klaw/-/klaw-1.3.1.tgz",
@@ -2929,33 +2569,6 @@
         "package-json": "^4.0.0"
       }
     },
-    "lazy-cache": {
-      "version": "1.0.4",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/lazy-cache/-/lazy-cache-1.0.4.tgz",
-      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
-      "optional": true
-    },
-    "lazystream": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-0.1.0.tgz",
-      "integrity": "sha1-GyXWPHcqTCDwpe0KnXf0hLbhaSA=",
-      "requires": {
-        "readable-stream": "~1.0.2"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
-    },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/lcid/-/lcid-1.0.0.tgz",
@@ -2970,15 +2583,6 @@
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/lcov-parse/-/lcov-parse-0.0.10.tgz",
       "integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
       "dev": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
     },
     "locate-path": {
       "version": "3.0.0",
@@ -3003,12 +2607,6 @@
       "requires": {
         "chalk": "^2.0.1"
       }
-    },
-    "longest": {
-      "version": "1.0.1",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "optional": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -3093,6 +2691,7 @@
       "version": "0.5.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -3100,7 +2699,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -3420,7 +3020,8 @@
     "ms": {
       "version": "0.7.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/ms/-/ms-0.7.1.tgz",
-      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
     },
     "mz": {
       "version": "2.7.0",
@@ -3455,11 +3056,6 @@
         "object.getownpropertydescriptors": "^2.0.3",
         "semver": "^5.7.0"
       }
-    },
-    "node-int64": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.3.3.tgz",
-      "integrity": "sha1-LW5rLs5d6FiLQ9iNG8QbJs0fqE0="
     },
     "nodemon": {
       "version": "2.0.0",
@@ -3524,6 +3120,7 @@
       "version": "3.0.6",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/nopt/-/nopt-3.0.6.tgz",
       "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "dev": true,
       "requires": {
         "abbrev": "1"
       }
@@ -3784,42 +3381,9 @@
       "version": "1.4.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
-      }
-    },
-    "optimist": {
-      "version": "0.6.1",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
-      "requires": {
-        "minimist": "~0.0.1",
-        "wordwrap": "~0.0.2"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "0.0.10",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-        },
-        "wordwrap": {
-          "version": "0.0.3",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
-        }
-      }
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
       }
     },
     "os-locale": {
@@ -3892,7 +3456,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -3932,11 +3497,6 @@
       "version": "0.3.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/pkginfo/-/pkginfo-0.3.1.tgz",
       "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -4010,22 +3570,6 @@
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/range-parser/-/range-parser-1.2.1.tgz",
       "integrity": "sha1-PPNwI9GZ4cJNGlW4SADC8+ZGgDE="
     },
-    "raw-body": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.0.2.tgz",
-      "integrity": "sha1-osL5jIUxzumcY9jSOLfel7tln8o=",
-      "requires": {
-        "bytes": "2.1.0",
-        "iconv-lite": "0.4.8"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "2.1.0",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/bytes/-/bytes-2.1.0.tgz",
-          "integrity": "sha1-rJPEEOL/ycx89LRks4KJBn9eR7Q="
-        }
-      }
-    },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/rc/-/rc-1.2.8.tgz",
@@ -4091,12 +3635,6 @@
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
       "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
       "dev": true
-    },
-    "repeat-string": {
-      "version": "1.6.1",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-      "optional": true
     },
     "request": {
       "version": "2.83.0",
@@ -4165,26 +3703,12 @@
       "integrity": "sha1-0LMp7MfMD2Fkn2IhW+aa9UqomJs=",
       "dev": true
     },
-    "resolve": {
-      "version": "1.1.7",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/resolve/-/resolve-1.1.7.tgz",
-      "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs="
-    },
     "resumer": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/resumer/-/resumer-0.0.0.tgz",
       "integrity": "sha1-8ej0YeQGS6Oegq883CqMiT0HZ1k=",
       "requires": {
         "through": "~2.3.4"
-      }
-    },
-    "right-align": {
-      "version": "0.1.3",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/right-align/-/right-align-0.1.3.tgz",
-      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "optional": true,
-      "requires": {
-        "align-text": "^0.1.1"
       }
     },
     "rimraf": {
@@ -4535,15 +4059,6 @@
         }
       }
     },
-    "source-map": {
-      "version": "0.2.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.2.0.tgz",
-      "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-      "optional": true,
-      "requires": {
-        "amdefine": ">=0.0.4"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -4634,7 +4149,8 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "stringify-clone": {
       "version": "1.1.1",
@@ -4770,30 +4286,6 @@
         "object-inspect": "~0.4.0",
         "resumer": "~0.0.0",
         "through": "~2.3.4"
-      }
-    },
-    "tar-stream": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.1.5.tgz",
-      "integrity": "sha1-vpIYwTDCACnhB7D5Z/sj3gV50Tw=",
-      "requires": {
-        "bl": "^0.9.0",
-        "end-of-stream": "^1.0.0",
-        "readable-stream": "~1.0.33",
-        "xtend": "^4.0.0"
-      },
-      "dependencies": {
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
       }
     },
     "term-size": {
@@ -4941,58 +4433,16 @@
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "optional": true
     },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
-    },
     "type-detect": {
       "version": "1.0.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/type-detect/-/type-detect-1.0.0.tgz",
       "integrity": "sha1-diIXzAbbJY7EiQihKY6LlRIejqI=",
       "dev": true
     },
-    "type-is": {
-      "version": "1.6.15",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/type-is/-/type-is-1.6.15.tgz",
-      "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.15"
-      }
-    },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
-    },
-    "uglify-js": {
-      "version": "2.8.29",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/uglify-js/-/uglify-js-2.8.29.tgz",
-      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
-      "optional": true,
-      "requires": {
-        "source-map": "~0.5.1",
-        "uglify-to-browserify": "~1.0.0",
-        "yargs": "~3.10.0"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "optional": true
-        }
-      }
-    },
-    "uglify-to-browserify": {
-      "version": "1.0.2",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
-      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
-      "optional": true
     },
     "undefsafe": {
       "version": "2.0.2",
@@ -5144,6 +4594,7 @@
       "version": "1.3.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/which/-/which-1.3.0.tgz",
       "integrity": "sha1-/wS9/AEO5UfXgL7DjhrBwnd9JTo=",
+      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }
@@ -5205,12 +4656,6 @@
         }
       }
     },
-    "window-size": {
-      "version": "0.1.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/window-size/-/window-size-0.1.0.tgz",
-      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
-      "optional": true
-    },
     "winston": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.2.0.tgz",
@@ -5232,11 +4677,6 @@
         }
       }
     },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-    },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
@@ -5250,7 +4690,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.4.3",
@@ -5280,7 +4721,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
@@ -5293,18 +4735,6 @@
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
-    },
-    "yargs": {
-      "version": "3.10.0",
-      "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/yargs/-/yargs-3.10.0.tgz",
-      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-      "optional": true,
-      "requires": {
-        "camelcase": "^1.0.2",
-        "cliui": "^2.1.0",
-        "decamelize": "^1.0.0",
-        "window-size": "0.1.0"
-      }
     },
     "yargs-parser": {
       "version": "13.1.1",
@@ -5419,34 +4849,6 @@
       "version": "0.1.2",
       "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-    },
-    "zip-stream": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-0.5.2.tgz",
-      "integrity": "sha1-Mty8UG0Nq00hNyYlvX66rDwv/1Y=",
-      "requires": {
-        "compress-commons": "~0.2.0",
-        "lodash": "~3.2.0",
-        "readable-stream": "~1.0.26"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.2.0.tgz",
-          "integrity": "sha1-S/UKMkP5rrC6xBpV09WZBnWkYvs="
-        },
-        "readable-stream": {
-          "version": "1.0.34",
-          "resolved": "https://repo.socrata.com:443/artifactory/api/npm/npm-virtual/readable-stream/-/readable-stream-1.0.34.tgz",
-          "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-          "requires": {
-            "core-util-is": "~1.0.0",
-            "inherits": "~2.0.1",
-            "isarray": "0.0.1",
-            "string_decoder": "~0.10.x"
-          }
-        }
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "deepmerge": "^1.3.0",
     "express": "4.17.1",
     "geojson-merge": "0.1.0",
-    "istanbul-middleware": "0.2.2",
+    "js-yaml": "^3.13.1",
     "lodash": "4.17.15",
     "memjs": "1.2.2",
     "numeral": "1.5.3",


### PR DESCRIPTION
…ebars < 4.3.0

## Prior to this change
> Versions of handlebars prior to 4.0.14 are vulnerable to Prototype Pollution.

Handlebars is being included by instanbul-middleware which is deprecated and no longer being updated.  It is a code coverage tool and we only loaded it in the dev environment.

## After this change

This change removes instanbul-middleware and its handlebars dependency.  It also explicitly adds js-yaml to the package.json, which was missing even though we use it.  Instanbul-middleware included js-yaml so it was loading it from there.

