### PR TITLE
Add configurable domain replacement for catalog API results

### DIFF
--- a/DOMAIN_REPLACEMENT.md
+++ b/DOMAIN_REPLACEMENT.md
@@ -1,0 +1,113 @@
+# Domain Replacement Feature
+
+## Overview
+
+This feature allows you to replace domain names returned from the Socrata Catalog API (`api.us.socrata.com`) with alternative domains. This is useful when datasets are migrated from one domain to another, or when you need to redirect users to a different domain for certain datasets.
+
+## Configuration
+
+Domain replacements are configured via the `DOMAIN_REPLACEMENTS` environment variable.
+
+### Format
+
+```
+DOMAIN_REPLACEMENTS="old-domain1.com:new-domain1.com,old-domain2.com:new-domain2.com"
+```
+
+- Multiple replacements are separated by commas (`,`)
+- Each replacement consists of the old domain and new domain separated by a colon (`:`)
+- Whitespace around domains is automatically trimmed
+- Invalid or malformed entries are skipped
+
+### Examples
+
+#### Single Domain Replacement
+
+Replace `datahub.austintexas.gov` with `data.austintexas.gov`:
+
+```bash
+export DOMAIN_REPLACEMENTS="datahub.austintexas.gov:data.austintexas.gov"
+```
+
+#### Multiple Domain Replacements
+
+Replace multiple domains:
+
+```bash
+export DOMAIN_REPLACEMENTS="datahub.austintexas.gov:data.austintexas.gov,old.example.com:new.example.com"
+```
+
+#### Docker/Container Deployment
+
+```dockerfile
+ENV DOMAIN_REPLACEMENTS="datahub.austintexas.gov:data.austintexas.gov"
+```
+
+#### Heroku Deployment
+
+```bash
+heroku config:set DOMAIN_REPLACEMENTS="datahub.austintexas.gov:data.austintexas.gov"
+```
+
+## Behavior
+
+- **Applied to**: Dataset search results from `/search/v1/dataset` endpoint
+- **Fields affected**:
+  - `domain` - The dataset's domain name
+  - `domain_url` - The HTTP URL to the domain
+  - `dev_docs_url` - The Socrata developer documentation URL
+- **Unmatched domains**: Domains not listed in `DOMAIN_REPLACEMENTS` are returned unchanged
+- **No configuration**: If `DOMAIN_REPLACEMENTS` is not set or is empty, no replacements occur
+
+## Implementation Details
+
+The domain replacement logic is implemented in two files:
+
+1. **`app/config.js`**: Parses the `DOMAIN_REPLACEMENTS` environment variable and creates a Map for efficient lookups
+2. **`app/search/dataset.js`**: Applies domain replacements when parsing dataset results from the Catalog API
+
+## Testing
+
+Tests are included in:
+- `test/domain-replacement.js` - Unit tests for config parsing
+- `test/dataset-domain-replacement.js` - Integration tests for dataset search
+
+Run tests with:
+```bash
+npm test
+```
+
+## Example
+
+**Environment variable:**
+```bash
+DOMAIN_REPLACEMENTS="datahub.austintexas.gov:data.austintexas.gov"
+```
+
+**API Response (before replacement):**
+```json
+{
+  "datasets": [{
+    "domain": "datahub.austintexas.gov",
+    "domain_url": "http://datahub.austintexas.gov",
+    "dev_docs_url": "https://dev.socrata.com/foundry/datahub.austintexas.gov/abc-123"
+  }]
+}
+```
+
+**API Response (after replacement):**
+```json
+{
+  "datasets": [{
+    "domain": "data.austintexas.gov",
+    "domain_url": "http://data.austintexas.gov",
+    "dev_docs_url": "https://dev.socrata.com/foundry/data.austintexas.gov/abc-123"
+  }]
+}
+```
+
+## Notes
+
+- The original `permalink` from the Catalog API is preserved and not modified
+- Domain replacements are case-sensitive
+- This feature only affects dataset search results; it does not modify other API endpoints

--- a/app/config.js
+++ b/app/config.js
@@ -24,6 +24,32 @@ var loadConfig = function() {
 const GlobalConfig = loadConfig();
 
 /**
+ * Parse domain replacements from environment variable.
+ * Format: "old1.com:new1.com,old2.com:new2.com"
+ * Returns a Map of old domain -> new domain
+ */
+const parseDomainReplacements = function() {
+  const replacements = new Map();
+  const envVar = process.env.DOMAIN_REPLACEMENTS;
+
+  if (!envVar || envVar.trim() === '') {
+    return replacements;
+  }
+
+  const pairs = envVar.split(',');
+  for (const pair of pairs) {
+    const [oldDomain, newDomain] = pair.split(':').map(s => s.trim());
+    if (oldDomain && newDomain) {
+      replacements.set(oldDomain, newDomain);
+    }
+  }
+
+  return replacements;
+};
+
+GlobalConfig.domain_replacements = parseDomainReplacements();
+
+/**
  * Makes this accessible inside of server side executed controllers stuff
  */
 if (typeof module !== 'undefined') module.exports = GlobalConfig;

--- a/app/search/dataset.js
+++ b/app/search/dataset.js
@@ -54,7 +54,12 @@ function searchDatasets(entities, searchTerms, limit, offset) {
 function getDataset(result) {
     const resource = result.resource;
     const fxf = resource.nbe_fxf || resource.id;
-    const domain = result.metadata.domain;
+    let domain = result.metadata.domain;
+
+    // Apply domain replacements if configured
+    if (Config.domain_replacements && Config.domain_replacements.has(domain)) {
+        domain = Config.domain_replacements.get(domain);
+    }
 
     return _.assign(_.pick(resource, ['name', 'description', 'attribution']), {
         fxf,

--- a/test/dataset-domain-replacement.js
+++ b/test/dataset-domain-replacement.js
@@ -1,0 +1,240 @@
+
+const assert = require('assert');
+
+describe('Dataset Domain Replacement in Search Results', () => {
+    let originalEnv;
+
+    beforeEach(() => {
+        // Save original environment
+        originalEnv = process.env.DOMAIN_REPLACEMENTS;
+        // Clear the require cache
+        delete require.cache[require.resolve('../app/config')];
+        delete require.cache[require.resolve('../app/search/dataset')];
+        delete require.cache[require.resolve('../app/request')];
+    });
+
+    afterEach(() => {
+        // Restore original environment
+        if (originalEnv !== undefined) {
+            process.env.DOMAIN_REPLACEMENTS = originalEnv;
+        } else {
+            delete process.env.DOMAIN_REPLACEMENTS;
+        }
+        // Clear the require cache
+        delete require.cache[require.resolve('../app/config')];
+        delete require.cache[require.resolve('../app/search/dataset')];
+        delete require.cache[require.resolve('../app/request')];
+    });
+
+    /**
+     * Helper to create a mock catalog API result
+     */
+    function createMockResult(domain, fxf) {
+        return {
+            resource: {
+                id: fxf,
+                nbe_fxf: fxf,
+                name: 'Test Dataset',
+                description: 'Test Description',
+                attribution: 'Test Attribution',
+                updatedAt: '2024-01-01T00:00:00.000Z',
+                createdAt: '2024-01-01T00:00:00.000Z'
+            },
+            metadata: {
+                domain: domain
+            },
+            permalink: `https://${domain}/d/${fxf}`,
+            classification: {
+                categories: ['test']
+            }
+        };
+    }
+
+    it('should replace domain when DOMAIN_REPLACEMENTS is set', (done) => {
+        process.env.DOMAIN_REPLACEMENTS = 'datahub.austintexas.gov:data.austintexas.gov';
+
+        const mockResults = [
+            createMockResult('datahub.austintexas.gov', 'test-fxf')
+        ];
+
+        const Request = require('../request');
+        const originalGetJSON = Request.getJSON;
+        const originalBuildURL = Request.buildURL;
+
+        // Mock Request.getJSON
+        Request.getJSON = () => Promise.resolve({ results: mockResults });
+        Request.buildURL = (path, params) => path;
+
+        const handler = require('../app/search/dataset');
+        const mockRequest = {};
+        const mockResponse = {
+            json: (data) => {
+                try {
+                    assert(data.datasets);
+                    assert.strictEqual(data.datasets.length, 1);
+                    assert.strictEqual(data.datasets[0].domain, 'data.austintexas.gov');
+                    assert.strictEqual(data.datasets[0].domain_url, 'http://data.austintexas.gov');
+                    assert.strictEqual(
+                        data.datasets[0].dev_docs_url,
+                        'https://dev.socrata.com/foundry/data.austintexas.gov/test-fxf'
+                    );
+
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done();
+                } catch (err) {
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done(err);
+                }
+            }
+        };
+
+        handler(mockRequest, mockResponse);
+    });
+
+    it('should not replace domain when DOMAIN_REPLACEMENTS is not set', (done) => {
+        delete process.env.DOMAIN_REPLACEMENTS;
+
+        const mockResults = [
+            createMockResult('datahub.austintexas.gov', 'test-fxf')
+        ];
+
+        const Request = require('../request');
+        const originalGetJSON = Request.getJSON;
+        const originalBuildURL = Request.buildURL;
+
+        // Mock Request.getJSON
+        Request.getJSON = () => Promise.resolve({ results: mockResults });
+        Request.buildURL = (path, params) => path;
+
+        const handler = require('../app/search/dataset');
+        const mockRequest = {};
+        const mockResponse = {
+            json: (data) => {
+                try {
+                    assert(data.datasets);
+                    assert.strictEqual(data.datasets.length, 1);
+                    assert.strictEqual(data.datasets[0].domain, 'datahub.austintexas.gov');
+                    assert.strictEqual(data.datasets[0].domain_url, 'http://datahub.austintexas.gov');
+                    assert.strictEqual(
+                        data.datasets[0].dev_docs_url,
+                        'https://dev.socrata.com/foundry/datahub.austintexas.gov/test-fxf'
+                    );
+
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done();
+                } catch (err) {
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done(err);
+                }
+            }
+        };
+
+        handler(mockRequest, mockResponse);
+    });
+
+    it('should only replace specified domains and leave others unchanged', (done) => {
+        process.env.DOMAIN_REPLACEMENTS = 'datahub.austintexas.gov:data.austintexas.gov';
+
+        const mockResults = [
+            createMockResult('datahub.austintexas.gov', 'test-fxf-1'),
+            createMockResult('data.seattle.gov', 'test-fxf-2')
+        ];
+
+        const Request = require('../request');
+        const originalGetJSON = Request.getJSON;
+        const originalBuildURL = Request.buildURL;
+
+        // Mock Request.getJSON
+        Request.getJSON = () => Promise.resolve({ results: mockResults });
+        Request.buildURL = (path, params) => path;
+
+        const handler = require('../app/search/dataset');
+        const mockRequest = {};
+        const mockResponse = {
+            json: (data) => {
+                try {
+                    assert(data.datasets);
+                    assert.strictEqual(data.datasets.length, 2);
+
+                    // First dataset should be replaced
+                    assert.strictEqual(data.datasets[0].domain, 'data.austintexas.gov');
+                    assert.strictEqual(data.datasets[0].domain_url, 'http://data.austintexas.gov');
+
+                    // Second dataset should remain unchanged
+                    assert.strictEqual(data.datasets[1].domain, 'data.seattle.gov');
+                    assert.strictEqual(data.datasets[1].domain_url, 'http://data.seattle.gov');
+
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done();
+                } catch (err) {
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done(err);
+                }
+            }
+        };
+
+        handler(mockRequest, mockResponse);
+    });
+
+    it('should handle multiple domain replacements correctly', (done) => {
+        process.env.DOMAIN_REPLACEMENTS = 'datahub.austintexas.gov:data.austintexas.gov,old.example.com:new.example.com';
+
+        const mockResults = [
+            createMockResult('datahub.austintexas.gov', 'test-fxf-1'),
+            createMockResult('old.example.com', 'test-fxf-2'),
+            createMockResult('data.seattle.gov', 'test-fxf-3')
+        ];
+
+        const Request = require('../request');
+        const originalGetJSON = Request.getJSON;
+        const originalBuildURL = Request.buildURL;
+
+        // Mock Request.getJSON
+        Request.getJSON = () => Promise.resolve({ results: mockResults });
+        Request.buildURL = (path, params) => path;
+
+        const handler = require('../app/search/dataset');
+        const mockRequest = {};
+        const mockResponse = {
+            json: (data) => {
+                try {
+                    assert(data.datasets);
+                    assert.strictEqual(data.datasets.length, 3);
+
+                    // First dataset should be replaced
+                    assert.strictEqual(data.datasets[0].domain, 'data.austintexas.gov');
+
+                    // Second dataset should be replaced
+                    assert.strictEqual(data.datasets[1].domain, 'new.example.com');
+
+                    // Third dataset should remain unchanged
+                    assert.strictEqual(data.datasets[2].domain, 'data.seattle.gov');
+
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done();
+                } catch (err) {
+                    // Restore
+                    Request.getJSON = originalGetJSON;
+                    Request.buildURL = originalBuildURL;
+                    done(err);
+                }
+            }
+        };
+
+        handler(mockRequest, mockResponse);
+    });
+});

--- a/test/domain-replacement.js
+++ b/test/domain-replacement.js
@@ -1,0 +1,127 @@
+
+const assert = require('assert');
+const _ = require('lodash');
+
+describe('Domain Replacement', () => {
+    let originalEnv;
+
+    beforeEach(() => {
+        // Save original environment
+        originalEnv = process.env.DOMAIN_REPLACEMENTS;
+        // Clear the require cache to reload config
+        delete require.cache[require.resolve('../app/config')];
+    });
+
+    afterEach(() => {
+        // Restore original environment
+        if (originalEnv !== undefined) {
+            process.env.DOMAIN_REPLACEMENTS = originalEnv;
+        } else {
+            delete process.env.DOMAIN_REPLACEMENTS;
+        }
+        // Clear the require cache to reload config
+        delete require.cache[require.resolve('../app/config')];
+    });
+
+    it('should parse single domain replacement from environment variable', () => {
+        process.env.DOMAIN_REPLACEMENTS = 'datahub.austintexas.gov:data.austintexas.gov';
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        assert.strictEqual(Config.domain_replacements.size, 1);
+        assert.strictEqual(
+            Config.domain_replacements.get('datahub.austintexas.gov'),
+            'data.austintexas.gov'
+        );
+    });
+
+    it('should parse multiple domain replacements from environment variable', () => {
+        process.env.DOMAIN_REPLACEMENTS = 'datahub.austintexas.gov:data.austintexas.gov,old.example.com:new.example.com';
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        assert.strictEqual(Config.domain_replacements.size, 2);
+        assert.strictEqual(
+            Config.domain_replacements.get('datahub.austintexas.gov'),
+            'data.austintexas.gov'
+        );
+        assert.strictEqual(
+            Config.domain_replacements.get('old.example.com'),
+            'new.example.com'
+        );
+    });
+
+    it('should handle empty environment variable', () => {
+        process.env.DOMAIN_REPLACEMENTS = '';
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        assert.strictEqual(Config.domain_replacements.size, 0);
+    });
+
+    it('should handle undefined environment variable', () => {
+        delete process.env.DOMAIN_REPLACEMENTS;
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        assert.strictEqual(Config.domain_replacements.size, 0);
+    });
+
+    it('should handle whitespace in environment variable', () => {
+        process.env.DOMAIN_REPLACEMENTS = '  datahub.austintexas.gov : data.austintexas.gov  ,  old.example.com : new.example.com  ';
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        assert.strictEqual(Config.domain_replacements.size, 2);
+        assert.strictEqual(
+            Config.domain_replacements.get('datahub.austintexas.gov'),
+            'data.austintexas.gov'
+        );
+        assert.strictEqual(
+            Config.domain_replacements.get('old.example.com'),
+            'new.example.com'
+        );
+    });
+
+    it('should skip malformed entries in environment variable', () => {
+        process.env.DOMAIN_REPLACEMENTS = 'datahub.austintexas.gov:data.austintexas.gov,invalid,old.example.com:new.example.com';
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        assert.strictEqual(Config.domain_replacements.size, 2);
+        assert.strictEqual(
+            Config.domain_replacements.get('datahub.austintexas.gov'),
+            'data.austintexas.gov'
+        );
+        assert.strictEqual(
+            Config.domain_replacements.get('old.example.com'),
+            'new.example.com'
+        );
+    });
+
+    it('should handle entries with only old domain', () => {
+        process.env.DOMAIN_REPLACEMENTS = 'datahub.austintexas.gov:,old.example.com:new.example.com';
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        // Only the valid entry should be parsed
+        assert.strictEqual(Config.domain_replacements.size, 1);
+        assert.strictEqual(
+            Config.domain_replacements.get('old.example.com'),
+            'new.example.com'
+        );
+    });
+
+    it('should handle entries with only new domain', () => {
+        process.env.DOMAIN_REPLACEMENTS = ':data.austintexas.gov,old.example.com:new.example.com';
+        const Config = require('../app/config');
+
+        assert(Config.domain_replacements instanceof Map);
+        // Only the valid entry should be parsed
+        assert.strictEqual(Config.domain_replacements.size, 1);
+        assert.strictEqual(
+            Config.domain_replacements.get('old.example.com'),
+            'new.example.com'
+        );
+    });
+});


### PR DESCRIPTION
This commit introduces a domain replacement feature that allows administrators to transparently replace domain names in dataset search results from the Socrata Catalog API.

Changes:
- Add DOMAIN_REPLACEMENTS environment variable support in app/config.js
  - Parses comma-separated "old:new" domain pairs
  - Creates a Map for efficient domain lookup
  - Handles whitespace and validates input format

- Update dataset search parser in app/search/dataset.js
  - Apply domain replacements to dataset results
  - Affects domain, domain_url, and dev_docs_url fields
  - Preserves original permalink from catalog API

- Add comprehensive test coverage
  - test/domain-replacement.js: Unit tests for config parsing
  - test/dataset-domain-replacement.js: Integration tests for search

- Add documentation in DOMAIN_REPLACEMENT.md

Use case: Replace deprecated domains with new ones (e.g., datahub.austintexas.gov -> data.austintexas.gov) without requiring catalog API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)